### PR TITLE
Options to interact with EU-stored Buckets

### DIFF
--- a/config/s3-sample.php
+++ b/config/s3-sample.php
@@ -4,5 +4,6 @@ return array(
 
 	'access_key' => '',
 	'secret_key' => '',
-
+	'use_ssl' => false,
+	'region' => 'EU' // either EU or US
 );

--- a/libraries/s3.php
+++ b/libraries/s3.php
@@ -27,7 +27,8 @@ class S3
 		$config = Config::get('s3'); // from application, not bundle
 		
 		// build object
-		$s3 = new Amazon\S3($config['access_key'], $config['secret_key']);
+		// now with ability to define SSL and endpoints
+		$s3 = new Amazon\S3($config['access_key'], $config['secret_key'], $config['use_ssl'], ($config['region'] == 'EU' ? 's3-eu-west-1.amazonaws.com' : 's3.amazonaws.com') );
 		
 		// return
 		return call_user_func_array(array($s3, self::camelize($method)), $args);

--- a/vendor/s3.php
+++ b/vendor/s3.php
@@ -372,7 +372,7 @@ class S3
 
 		if ($location !== false)
 		{
-			$dom = new DOMDocument;
+			$dom = new \DomDocument;
 			$createBucketConfiguration = $dom->createElement('CreateBucketConfiguration');
 			$locationConstraint = $dom->createElement('LocationConstraint', $location);
 			$createBucketConfiguration->appendChild($locationConstraint);
@@ -707,7 +707,7 @@ class S3
 			if (!$aclReadSet || !$aclWriteSet) self::setAccessControlPolicy($targetBucket, '', $acp);
 		}
 
-		$dom = new DOMDocument;
+		$dom = new \DomDocument;
 		$bucketLoggingStatus = $dom->createElement('BucketLoggingStatus');
 		$bucketLoggingStatus->setAttribute('xmlns', 'http://s3.amazonaws.com/doc/2006-03-01/');
 		if ($targetBucket !== null)
@@ -814,7 +814,7 @@ class S3
 	*/
 	public static function setAccessControlPolicy($bucket, $uri = '', $acp = array())
 	{
-		$dom = new DOMDocument;
+		$dom = new \DomDocument;
 		$dom->formatOutput = true;
 		$accessControlPolicy = $dom->createElement('AccessControlPolicy');
 		$accessControlList = $dom->createElement('AccessControlList');
@@ -1388,14 +1388,14 @@ class S3
 
 
 	/**
-	* Get a InvalidationBatch DOMDocument
+	* Get a InvalidationBatch \DomDocument
 	*
 	* @internal Used to create XML in invalidateDistribution()
 	* @param array $paths Paths to objects to invalidateDistribution
 	* @return string
 	*/
 	private static function __getCloudFrontInvalidationBatchXML($paths, $callerReference = '0') {
-		$dom = new DOMDocument('1.0', 'UTF-8');
+		$dom = new \DomDocument('1.0', 'UTF-8');
 		$dom->formatOutput = true;
 		$invalidationBatch = $dom->createElement('InvalidationBatch');
 		foreach ($paths as $path)
@@ -1408,7 +1408,7 @@ class S3
 
 
 	/**
-	* Get a DistributionConfig DOMDocument
+	* Get a DistributionConfig \DomDocument
 	*
 	* http://docs.amazonwebservices.com/AmazonCloudFront/latest/APIReference/index.html?PutConfig.html
 	*
@@ -1425,7 +1425,7 @@ class S3
 	*/
 	private static function __getCloudFrontDistributionConfigXML($bucket, $enabled, $comment, $callerReference = '0', $cnames = array(), $defaultRootObject = null, $originAccessIdentity = null, $trustedSigners = array())
 	{
-		$dom = new DOMDocument('1.0', 'UTF-8');
+		$dom = new \DomDocument('1.0', 'UTF-8');
 		$dom->formatOutput = true;
 		$distributionConfig = $dom->createElement('DistributionConfig');
 		$distributionConfig->setAttribute('xmlns', 'http://cloudfront.amazonaws.com/doc/2010-11-01/');


### PR DESCRIPTION
Added the ability to define whether or not you would like to use SSL
for transfers and whether or not your Bucket is stored in the EU or not
(as this affects the endpoint required by Amazon).

Your code worked fine for US based buckets, but these additions will enable it to work for those who have buckets stored within the EU. 
